### PR TITLE
fix: set x-vtex-account header on requests

### DIFF
--- a/react/actions/order-actions.js
+++ b/react/actions/order-actions.js
@@ -39,9 +39,11 @@ const ORDERS_DETAILED_LOADED_LIMIT = 3
 let listingResponseGuid = ''
 
 async function loadOrders({ page, guid }) {
+  const { account } = window.__RUNTIME__
   const headers = {
     [OPERATION_ID_HEADER]: guid,
     'x-vtex-user-agent': process.env.VTEX_APP_ID,
+    'x-vtex-account': account,
   }
 
   return fetch(await getOrdersURL(BASE_URL, page ?? '1'), {
@@ -58,10 +60,12 @@ async function loadOrders({ page, guid }) {
 }
 
 async function loadOrder(orderId, listingGuid) {
+  const { account } = window.__RUNTIME__
   const guid = getGUID()
   const headers = {
     [OPERATION_ID_HEADER]: guid,
     'x-vtex-user-agent': process.env.VTEX_APP_ID,
+    'x-vtex-account': account,
   }
 
   let detailResponseGuid = ''
@@ -381,12 +385,15 @@ export const cancelOrder = (orderId, reason = '') => async dispatch => {
     addBaseURL(`/api/checkout/pub/orders/${orderId}/user-cancel-request`)
   )
 
+  const { account } = window.__RUNTIME__
+
   return fetch(url, {
     credentials: 'same-origin',
     method: 'POST',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json; charset=utf-8',
+      'x-vtex-account': account,
     },
     body: JSON.stringify(data),
   })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the bug with the order history page and send the header `x-vtex-account` for the requests to backend.

#### What problem is this solving?
It was reported that there is a bug for some clients with custom domains where the order history doesn't work and returns "Access Denied".

I found the problem [here](https://github.com/vtex-apps/b2b-organizations-graphql/blob/master/node/resolvers/Routes/index.ts#L16), where the backend tries to get a token by cookie, but it is null.

In the VTEX API, the storeUserAuthToken in the context, it is filled by the cookie `ctx.cookies.get(`${VTEX_ID_COOKIE_KEY}_${account}`)` and the account name or id. Currently, the account must be sent with the header `x-vtex-account` and it isn't.

#### How should this be manually tested?

-     Access My Account - Orders in the website domain;
-     The message "You don't have permission to access this." will be shown.

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
