### PR TITLE
Fix order again button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix order again button
+
 ## [0.3.0] - 2023-07-21
 
 ### Fixed

--- a/react/components/Order/OrderActions.js
+++ b/react/components/Order/OrderActions.js
@@ -30,9 +30,8 @@ class OrderActions extends Component {
   }
 
   handleOrderAgainClick = () => {
-    const {
-      order: { orderGroup },
-    } = this.props
+    const { order } = this.props
+    const { orderGroup } = order
 
     return window.open(
       addBaseURL(`/checkout/orderform/createBy/${orderGroup}`),
@@ -50,7 +49,7 @@ class OrderActions extends Component {
       paymentData: { transactions },
     } = order
 
-    const isOwner = email === this.state.loggedInEmail
+    const isOwner = email.startsWith(this.state.loggedInEmail)
     const showEditOrderButton = allowSAC && allowEdition && isOwner
     const showCancelOrderButton = allowCancellation
     const bankInvoiceUrl = OrderUtils.getBankInvoiceUrl(transactions)

--- a/react/components/ViewOrder/OrderButtons.js
+++ b/react/components/ViewOrder/OrderButtons.js
@@ -42,7 +42,7 @@ const OrderActions = ({ order, allowSAC }) => {
     }
   }, [setLoggedInEmail])
 
-  const isOwner = clientEmail === loggedInEmail
+  const isOwner = clientEmail.startsWith(loggedInEmail)
   const showEditOrderButton = allowSAC && allowEdition && isOwner
   const showCancelOrderButton = allowCancellation
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
https://vtex-dev.atlassian.net/browse/B2BTEAM-1187

Due to a change on the OMS API used to retrieve order information (see: https://github.com/vtex-apps/b2b-organizations-graphql/pull/124), now the `clientProfileData.email` field returns information a bit different. Before it would return something like `enzo@vtex.com.br` and now it returns something like: `enzo@vtex.com.br-123900000144a.ct.vtex.com.br`.

So, to decide if we should show the order again button or not, instead of using `==` to compare the email strings, we check if the order email starts with the same value as the current user email.

#### What problem is this solving?
Properly show the order again button after changing the OMS api used to retrieve order information (as the email field is returned a bit different now).

#### How should this be manually tested?
Install fixed versions of `b2b-organizations-graphql` and `b2b-orders-history` apps, create an order and use the admin UI to complete it. After that, do the following:

Access Orders (/orders-history) from My Account;
Click on Order Again;
A cart with the items from a previous order should be created (previously an error page would appear with the message "Sorry, an error occurred while processing your request.")

#### Screenshots or example usage
See description of: https://github.com/vtex-apps/b2b-organizations-graphql/pull/124

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
