### PR TITLE
chore: major update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update dependency major version. If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
+    - vtex.b2b-admin-customers@2.x
+    - vtex.b2b-checkout-settings@3.x
+    - vtex.b2b-my-account@2.x
+    - vtex.b2b-orders-history@2.x
+    - vtex.b2b-organizations@3.x
+    - vtex.b2b-organizations-graphql@2.x
+    - vtex.b2b-quotes@3.x
+    - vtex.b2b-quotes-graphql@4.x
+    - vtex.b2b-suite@2.x
+    - vtex.b2b-theme@5.x
+    - vtex.storefront-permissions-components@2.x
+    - vtex.storefront-permissions-ui@1.x
+
 ## [1.0.0] - 2025-05-27
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "store": "0.x",
     "messages": "1.x",
     "docs": "0.x",
-    "vtex.storefront-permissions": "2.x"
+    "vtex.storefront-permissions": "3.x"
   },
   "dependencies": {
     "vtex.my-account": "1.x",


### PR DESCRIPTION
**What problem is this solving?**

Generating new major version. This new version includes ACL feature. Now the following permissions are needed to view/edit organizations within the admin UI app:
`Buyer Organizations / buyer_organization_view`
`Buyer Organizations / buyer_organization_edit`

If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
    - vtex.b2b-admin-customers@2.x
    - vtex.b2b-checkout-settings@3.x
    - vtex.b2b-my-account@2.x
    - vtex.b2b-orders-history@2.x
    - vtex.b2b-organizations@3.x
    - vtex.b2b-organizations-graphql@2.x
    - vtex.b2b-quotes@3.x
    - vtex.b2b-quotes-graphql@4.x
    - vtex.b2b-suite@2.x
    - vtex.b2b-theme@5.x
    - vtex.storefront-permissions-components@2.x
    - vtex.storefront-permissions-ui@1.x